### PR TITLE
Remove switch_sub_account_type (dead endpoint)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -228,10 +228,6 @@ class TestVoiceIt2(unittest.TestCase):
         self.assertEqual('SUCC', ret['responseCode'])
         unmanaged_sub_account = ret['apiKey']
 
-        ret = my_voiceit.switch_sub_account_type(ret['apiKey'])
-        self.assertEqual(200, ret['status'])
-        self.assertEqual('SUCC', ret['responseCode'])
-
         print('   Testing Create Managed Sub Account')
         ret = my_voiceit.create_managed_sub_account("Test", "Python", "", "", "")
         self.assertEqual(201, ret['status'])

--- a/voiceit2/voiceit2.py
+++ b/voiceit2/voiceit2.py
@@ -66,12 +66,6 @@ class VoiceIt2:
         except requests.exceptions.HTTPError as e:
             return e.read()
     
-    def switch_sub_account_type(self, subAccountAPIKey):
-        try:
-            response = requests.post(self.base_url + '/subaccount/' + subAccountAPIKey + '/switchType' + self.notification_url, auth=self.voiceit_basic_auth_credentials, headers=self.headers)
-            return response.json()
-        except requests.exceptions.HTTPError as e:
-            return e.read()
 
     def regenerate_sub_account_api_token(self, sub_account_api_key):
         try:


### PR DESCRIPTION
## Summary
- Removes `switch_sub_account_type()` method from `voiceit2.py` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)